### PR TITLE
Instead of serial numbers to differentiate between truncated column-names use a hashes

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,4 @@
-name: csv-parser
+name: datastore
 type: php
 docroot: ""
 php_version: "7.3"

--- a/src/Storage/Database/SqlStorageTrait.php
+++ b/src/Storage/Database/SqlStorageTrait.php
@@ -54,7 +54,8 @@ trait SqlStorageTrait
         return $this->schema;
     }
 
-    public function generateToken($field) {
+    public function generateToken($field)
+    {
         $md5 = md5($field);
         return substr($md5, 0, 4);
     }

--- a/src/Storage/Database/SqlStorageTrait.php
+++ b/src/Storage/Database/SqlStorageTrait.php
@@ -29,7 +29,7 @@ trait SqlStorageTrait
             $mysqlMaxColLength = 64;
             if (strlen($new) >= $mysqlMaxColLength) {
                 $strings = str_split($new, $mysqlMaxColLength - 5);
-                $token = self::generateToken($field);
+                $token = $this->generateToken($field);
                 $new = $strings[0] . "_{$token}";
             }
 
@@ -54,8 +54,8 @@ trait SqlStorageTrait
         return $this->schema;
     }
 
-    public static function generateToken($field) {
+    public function generateToken($field) {
       $md5 = md5($field);
-      return str_split($md5, 4);
+      return substr($md5, 0, 4);
     }
 }

--- a/src/Storage/Database/SqlStorageTrait.php
+++ b/src/Storage/Database/SqlStorageTrait.php
@@ -18,7 +18,6 @@ trait SqlStorageTrait
      */
     private function cleanSchema()
     {
-        $counter = 0;
         $cleanSchema = $this->schema;
         $cleanSchema['fields'] = [];
         foreach ($this->schema['fields'] as $field => $info) {
@@ -30,8 +29,8 @@ trait SqlStorageTrait
             $mysqlMaxColLength = 64;
             if (strlen($new) >= $mysqlMaxColLength) {
                 $strings = str_split($new, $mysqlMaxColLength - 5);
-                $new = $strings[0] . "_{$counter}";
-                $counter++;
+                $token = self::generateToken($field);
+                $new = $strings[0] . "_{$token}";
             }
 
             if ($field != $new) {
@@ -53,5 +52,10 @@ trait SqlStorageTrait
     public function getSchema()
     {
         return $this->schema;
+    }
+
+    public static function generateToken($field) {
+      $md5 = md5($field);
+      return str_split($md5, 4);
     }
 }

--- a/src/Storage/Database/SqlStorageTrait.php
+++ b/src/Storage/Database/SqlStorageTrait.php
@@ -55,7 +55,7 @@ trait SqlStorageTrait
     }
 
     public function generateToken($field) {
-      $md5 = md5($field);
-      return substr($md5, 0, 4);
+        $md5 = md5($field);
+        return substr($md5, 0, 4);
     }
 }

--- a/test/ImporterTest.php
+++ b/test/ImporterTest.php
@@ -99,13 +99,17 @@ class ImporterTest extends TestCase
     {
         $resource = new Resource(1, __DIR__ . "/data/longcolumn.csv", "text/csv");
         $datastore = $this->getDatastore($resource);
-        $truncatedLongFieldName = 'extra_long_column_name_with_tons_of_characters_that_will_ne_0';
+        $truncatedLongFieldName = 'extra_long_column_name_with_tons_of_characters_that_will_ne_e872';
 
         $datastore->run();
         $schema = $datastore->getStorage()->getSchema();
         $fields = array_keys($schema['fields']);
 
         $this->assertEquals($truncatedLongFieldName, $fields[2]);
+        $this->assertEquals(64, strlen($fields[2]));
+
+        $this->assertNotEquals($fields[3], $truncatedLongFieldName);
+        $this->assertEquals(64, strlen($fields[3]));
     }
 
     public function testColumnNameSpaces()

--- a/test/data/longcolumn.csv
+++ b/test/data/longcolumn.csv
@@ -1,3 +1,3 @@
-"id", "name", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work"
-1, "Greg", 45.6
-2, "Mary", 22.1
+"id", "name", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work2"
+1, "Greg", 45.6, 4
+2, "Mary", 22.1, 7


### PR DESCRIPTION
When we truncate column-names due to database size restrictions, there is a possibility of creating new names that are not unique:
For example if we have 2 columns that need to be truncated (my_name_is_j and my_name_is_k) any truncation to these column names will result in names that are not unique (Ex. my_name_is).

To solve this problem we add a number at the end of the column-name after truncation. Truncating our 2 sample columns will result in: my_name_is_1 and my_name_is_2.

This approach solves our issue but it is volatile. Given the implementation, if any new columns that need to be truncated are added before our current columns, the column name will be changed. So my_name_is_1 might be my_name_is_2 in another iteration of the same file.

We would like to be able to solve the problem in a less volatile way. For this purpose, this PR changes the current approach to instead use the first 4 characters of a md5 hash of the original string. This should give us a unique value to append to truncated columns with less volatility: my_name_is_7y87 and my_name_is_9okl.